### PR TITLE
Provenance Generation

### DIFF
--- a/eventhandler.go
+++ b/eventhandler.go
@@ -127,20 +127,29 @@ func (eventHandler *EventHandler) handleProcessEvent(event *Event) {
 
 				if event.ProcessArguments[idx+1] == "build" {
 
-					cli, err := client.NewClientWithOpts(client.FromEnv)
+					cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 					if err != nil {
 						panic(err)
+						WriteLog("ERROR AT NEWCLIENTWITHOPTS")
 					}
 
 					containers, err := cli.ContainerList(context.Background(), types.ContainerListOptions{})
 					if err != nil {
 						panic(err)
+						WriteLog("ERROR AT CONTAINERS")
 					}
 
 					for _, container := range containers {
+						WriteLog("Writing containers")
 						WriteLog(container.ID[:10])
 						WriteLog(container.Image)
-						//fmt.Printf("%s %s\n", container.ID[:10], container.Image)
+						WriteLog(fmt.Sprintf("%s %s\n", container.ID[:10], container.Image))
+						
+					}
+					images, _ := cli.ImageList(ctx, types.ImageListOptions{All: true})
+					for _, image := range images {
+						WriteLog("Writing images")
+						WriteLog(fmt.Sprintf("image: %v", image))
 					}
 
 					provdump := provgen()

--- a/eventhandler.go
+++ b/eventhandler.go
@@ -121,9 +121,10 @@ func (eventHandler *EventHandler) handleProcessEvent(event *Event) {
 	if !found {
 		eventHandler.ProcessMap[event.Pid] = &Process{PID: event.Pid, PPid: event.PPid, Exe: event.Exe, Arguments: event.ProcessArguments}
 		
-		WriteLog("Arguments:")
+		
 		for idx, value := range event.ProcessArguments {
 			if value == "npm"{
+				WriteLog("Arguments:")
 				WriteLog(value)
 				WriteLog(event.ProcessArguments[idx+1])
 			}

--- a/eventhandler.go
+++ b/eventhandler.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -12,7 +13,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"strconv"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
@@ -121,14 +121,16 @@ func (eventHandler *EventHandler) handleProcessEvent(event *Event) {
 	if !found {
 		eventHandler.ProcessMap[event.Pid] = &Process{PID: event.Pid, PPid: event.PPid, Exe: event.Exe, Arguments: event.ProcessArguments}
 
-		for idx, value := range event.ProcessArguments {
-			
-			arg := strconv.Itoa(idx) +" (+) " + value
-			
-			WriteLog(arg)
+		for _, value := range event.ProcessArguments {
+
 			if value == "docker" {
-				WriteLog("Special Arguments:")
-				WriteLog(value)
+
+				provdump := provgen()
+
+				payload, _ := json.MarshalIndent(provdump, "", "  ")
+
+				WriteLog(string(payload))
+
 				//WriteLog(event.ProcessArguments[idx+1])
 			}
 

--- a/eventhandler.go
+++ b/eventhandler.go
@@ -146,7 +146,7 @@ func (eventHandler *EventHandler) handleProcessEvent(event *Event) {
 						WriteLog(fmt.Sprintf("%s %s\n", container.ID[:10], container.Image))
 						
 					}
-					images, _ := cli.ImageList(ctx, types.ImageListOptions{All: true})
+					images, _ := cli.ImageList(context.Background(), types.ImageListOptions{All: true})
 					for _, image := range images {
 						WriteLog("Writing images")
 						WriteLog(fmt.Sprintf("image: %v", image))

--- a/eventhandler.go
+++ b/eventhandler.go
@@ -123,7 +123,7 @@ func (eventHandler *EventHandler) handleProcessEvent(event *Event) {
 
 		for idx, value := range event.ProcessArguments {
 
-			if value == "docker" && len(event.ProcessArguments) >= 2 {
+			if value == "docker" && len(event.ProcessArguments) >= 2 && idx < len(event.ProcessArguments) - 1 {
 
 				if event.ProcessArguments[idx+1] == "build" {
 

--- a/eventhandler.go
+++ b/eventhandler.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"

--- a/eventhandler.go
+++ b/eventhandler.go
@@ -119,6 +119,11 @@ func (eventHandler *EventHandler) handleProcessEvent(event *Event) {
 
 	if !found {
 		eventHandler.ProcessMap[event.Pid] = &Process{PID: event.Pid, PPid: event.PPid, Exe: event.Exe, Arguments: event.ProcessArguments}
+		
+		WriteLog("Arguments:")
+		for _, value := range event.ProcessArguments {
+			WriteLog(value)
+		}
 	}
 
 	eventHandler.procMutex.Unlock()

--- a/eventhandler.go
+++ b/eventhandler.go
@@ -43,7 +43,6 @@ func (eventHandler *EventHandler) handleFileEvent(event *Event) {
 	if strings.Contains(event.FileName, "post_event.json") {
 		WriteLog("\n")
 		WriteLog("post_event called")
-		WriteLog("arjundashrath/agent works")
 
 		// send done signal to post step
 		writeDone()
@@ -120,15 +119,14 @@ func (eventHandler *EventHandler) handleProcessEvent(event *Event) {
 
 	if !found {
 		eventHandler.ProcessMap[event.Pid] = &Process{PID: event.Pid, PPid: event.PPid, Exe: event.Exe, Arguments: event.ProcessArguments}
-		
-		
+
 		for idx, value := range event.ProcessArguments {
-			if value == "npm"{
+			if value == "docker" {
 				WriteLog("Arguments:")
 				WriteLog(value)
 				WriteLog(event.ProcessArguments[idx+1])
 			}
-			
+
 		}
 	}
 

--- a/eventhandler.go
+++ b/eventhandler.go
@@ -128,7 +128,7 @@ func (eventHandler *EventHandler) handleProcessEvent(event *Event) {
 
 				if event.ProcessArguments[idx+1] == "build" {
 					
-					time.Sleep(10 * time.Second)
+					time.Sleep(30 * time.Second)
 					WriteLog("\n")
 					cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 					if err != nil {

--- a/eventhandler.go
+++ b/eventhandler.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"strconv"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
@@ -122,7 +123,7 @@ func (eventHandler *EventHandler) handleProcessEvent(event *Event) {
 
 		for idx, value := range event.ProcessArguments {
 			
-			arg := idx +"(+)" + value
+			arg := strconv.Itoa(idx) +" (+) " + value
 			
 			WriteLog(arg)
 			if value == "docker" {

--- a/eventhandler.go
+++ b/eventhandler.go
@@ -155,7 +155,7 @@ func (eventHandler *EventHandler) handleProcessEvent(event *Event) {
 						WriteLog(fmt.Sprintf("image: %v", image))
 					}
 
-					provdump := provgen()
+					provdump := provgen(event.ProcessArguments)
 
 					payload, _ := json.MarshalIndent(provdump, "", "  ")
 

--- a/eventhandler.go
+++ b/eventhandler.go
@@ -43,6 +43,7 @@ func (eventHandler *EventHandler) handleFileEvent(event *Event) {
 	if strings.Contains(event.FileName, "post_event.json") {
 		WriteLog("\n")
 		WriteLog("post_event called")
+		WriteLog("arjundashrath/agent works")
 
 		// send done signal to post step
 		writeDone()

--- a/eventhandler.go
+++ b/eventhandler.go
@@ -121,8 +121,12 @@ func (eventHandler *EventHandler) handleProcessEvent(event *Event) {
 		eventHandler.ProcessMap[event.Pid] = &Process{PID: event.Pid, PPid: event.PPid, Exe: event.Exe, Arguments: event.ProcessArguments}
 
 		for idx, value := range event.ProcessArguments {
+			
+			arg := idx +" (+) " + value
+			
+			WriteLog(arg)
 			if value == "docker" {
-				WriteLog("Arguments:")
+				WriteLog("Special Arguments:")
 				WriteLog(value)
 				WriteLog(event.ProcessArguments[idx+1])
 			}

--- a/eventhandler.go
+++ b/eventhandler.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
@@ -127,6 +128,7 @@ func (eventHandler *EventHandler) handleProcessEvent(event *Event) {
 
 				if event.ProcessArguments[idx+1] == "build" {
 					
+					time.Sleep(10 * time.Second)
 					WriteLog("\n")
 					cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 					if err != nil {

--- a/eventhandler.go
+++ b/eventhandler.go
@@ -122,11 +122,12 @@ func (eventHandler *EventHandler) handleProcessEvent(event *Event) {
 		eventHandler.ProcessMap[event.Pid] = &Process{PID: event.Pid, PPid: event.PPid, Exe: event.Exe, Arguments: event.ProcessArguments}
 
 		for idx, value := range event.ProcessArguments {
-
+			WriteLog(value)
 			if value == "docker" && len(event.ProcessArguments) >= 2 && idx < len(event.ProcessArguments) - 1 {
 
 				if event.ProcessArguments[idx+1] == "build" {
-
+					
+					WriteLog("\n")
 					cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 					if err != nil {
 						panic(err)

--- a/eventhandler.go
+++ b/eventhandler.go
@@ -122,7 +122,7 @@ func (eventHandler *EventHandler) handleProcessEvent(event *Event) {
 
 		for idx, value := range event.ProcessArguments {
 			
-			arg := idx +" (+) " + value
+			arg := idx +"(+)" + value
 			
 			WriteLog(arg)
 			if value == "docker" {

--- a/eventhandler.go
+++ b/eventhandler.go
@@ -123,12 +123,11 @@ func (eventHandler *EventHandler) handleProcessEvent(event *Event) {
 		eventHandler.ProcessMap[event.Pid] = &Process{PID: event.Pid, PPid: event.PPid, Exe: event.Exe, Arguments: event.ProcessArguments}
 
 		for idx, value := range event.ProcessArguments {
-			WriteLog(value)
+			//WriteLog(value)
 			if value == "docker" && len(event.ProcessArguments) >= 2 && idx < len(event.ProcessArguments) - 1 {
 
 				if event.ProcessArguments[idx+1] == "build" {
 					
-					time.Sleep(30 * time.Second)
 					WriteLog("\n")
 					cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 					if err != nil {

--- a/eventhandler.go
+++ b/eventhandler.go
@@ -122,8 +122,12 @@ func (eventHandler *EventHandler) handleProcessEvent(event *Event) {
 		eventHandler.ProcessMap[event.Pid] = &Process{PID: event.Pid, PPid: event.PPid, Exe: event.Exe, Arguments: event.ProcessArguments}
 		
 		WriteLog("Arguments:")
-		for _, value := range event.ProcessArguments {
-			WriteLog(value)
+		for idx, value := range event.ProcessArguments {
+			if value == "npm"{
+				WriteLog(value)
+				WriteLog(event.ProcessArguments[idx+1])
+			}
+			
 		}
 	}
 

--- a/eventhandler.go
+++ b/eventhandler.go
@@ -129,7 +129,7 @@ func (eventHandler *EventHandler) handleProcessEvent(event *Event) {
 			if value == "docker" {
 				WriteLog("Special Arguments:")
 				WriteLog(value)
-				WriteLog(event.ProcessArguments[idx+1])
+				//WriteLog(event.ProcessArguments[idx+1])
 			}
 
 		}

--- a/provenance.go
+++ b/provenance.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"time"
+)
+
+var (
+	artifactPath  = flag.String("artifact_path", "", "The file or dir path of the artifacts for which provenance should be generated.")
+	outputPath    = flag.String("output_path", "build.provenance", "The path to which the generated provenance should be written.")
+	githubContext = flag.String("github_context", "", "The '${github}' context value.")
+	runnerContext = flag.String("runner_context", "", "The '${runner}' context value.")
+)
+
+const (
+	GitHubHostedIdSuffix = "/Attestations/GitHubHostedActions@v1"
+	SelfHostedIdSuffix   = "/Attestations/SelfHostedActions@v1"
+	TypeId               = "https://github.com/Attestations/arjundashrath/harden-runner@v1"
+	PayloadContentType   = "application/vnd.in-toto+json"
+)
+
+type GitHubContext struct {
+	Action          string          `json:"action"`
+	ActionPath      string          `json:"action_path"`
+	Actor           string          `json:"actor"`
+	BaseRef         string          `json:"base_ref"`
+	Event           json.RawMessage `json:"event"`
+	EventName       string          `json:"event_name"`
+	EventPath       string          `json:"event_path"`
+	HeadRef         string          `json:"head_ref"`
+	Job             string          `json:"job"`
+	Ref             string          `json:"ref"`
+	Repository      string          `json:"repository"`
+	RepositoryOwner string          `json:"repository_owner"`
+	RunId           string          `json:"run_id"`
+	RunNumber       string          `json:"run_number"`
+	SHA             string          `json:"sha"`
+	Token           string          `json:"token,omitempty"`
+	Workflow        string          `json:"workflow"`
+	Workspace       string          `json:"workspace"`
+}
+type RunnerContext struct {
+	OS        string `json:"os"`
+	Temp      string `json:"temp"`
+	ToolCache string `json:"tool_cache"`
+}
+
+type Statement struct {
+	Type          string    `json:"_type"`
+	Subject       []Subject `json:"subject"`
+	PredicateType string    `json:"predicateType"`
+	Predicate     `json:"predicate"`
+}
+
+type Subject struct {
+	Name   string    `json:"name"`
+	Digest DigestSet `json:"digest"`
+}
+
+//func generateSubject() Subject {
+//TO DO
+//}
+
+type DigestSet map[string]string
+type Item struct {
+	URI    string    `json:"uri"`
+	Digest DigestSet `json:"digest"`
+}
+
+type AnyContext struct {
+	GitHubContext `json:"github"`
+	RunnerContext `json:"runner"`
+}
+
+type Predicate struct {
+	Builder   `json:"builder"`
+	Metadata  `json:"metadata"`
+	Recipe    `json:"recipe"`
+	Materials []Item `json:"materials"`
+}
+type Builder struct {
+	Id string `json:"id"`
+}
+type Metadata struct {
+	BuildInvocationId string `json:"buildInvocationId"`
+	Completeness      `json:"completeness"`
+	Reproducible      bool `json:"reproducible"`
+	// BuildStartedOn not defined as it's not available from a GitHub Action.
+	BuildFinishedOn string `json:"buildFinishedOn"`
+}
+type Recipe struct {
+	Type              string          `json:"type"`
+	DefinedInMaterial int             `json:"definedInMaterial"`
+	EntryPoint        string          `json:"entryPoint"`
+	Arguments         json.RawMessage `json:"arguments"`
+	Environment       *AnyContext     `json:"environment"`
+}
+type Completeness struct {
+	Arguments   bool `json:"arguments"`
+	Environment bool `json:"environment"`
+	Materials   bool `json:"materials"`
+}
+
+func provgen() Statement {
+
+	stm := Statement{PredicateType: "https://slsa.dev/provenance/v0.1", Type: "https://in-toto.io/Statement/v0.1"}
+	//stm.Subject = append(stmt.Subject, generateSubject...)
+	stm.Predicate = Predicate{
+		Builder{},
+		Metadata{
+			Completeness: Completeness{
+				Arguments:   true,
+				Environment: false,
+				Materials:   false,
+			},
+			Reproducible:    false,
+			BuildFinishedOn: time.Now().UTC().Format(time.RFC3339),
+		},
+		Recipe{
+			Type:              TypeId,
+			DefinedInMaterial: 0,
+		},
+		[]Item{},
+	}
+
+	context := AnyContext{}
+	if err := json.Unmarshal([]byte(*githubContext), &context.GitHubContext); err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal([]byte(*runnerContext), &context.RunnerContext); err != nil {
+		panic(err)
+	}
+
+	gh := context.GitHubContext
+
+	// NOTE: Re-runs are not uniquely identified and can cause run ID collisions.
+	repourl := "https://github.com/" + gh.Repository
+
+	stm.Predicate.Builder.Id = repourl
+
+	stm.Predicate.Metadata.BuildInvocationId = repourl + "/actions/runs/" + gh.RunId
+
+	return stm
+}

--- a/provenance.go
+++ b/provenance.go
@@ -7,8 +7,6 @@ import (
 )
 
 var (
-	artifactPath  = flag.String("artifact_path", "", "The file or dir path of the artifacts for which provenance should be generated.")
-	outputPath    = flag.String("output_path", "build.provenance", "The path to which the generated provenance should be written.")
 	githubContext = flag.String("github_context", "", "The '${github}' context value.")
 	runnerContext = flag.String("runner_context", "", "The '${runner}' context value.")
 )
@@ -125,11 +123,17 @@ func provgen() Statement {
 	}
 
 	context := AnyContext{}
+	/*if err := json.Unmarshal([]byte(*githubContext), &context.GitHubContext); err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal([]byte(*runnerContext), &context.RunnerContext); err != nil {
+		panic(err)
+	}*/
 
 	gh := context.GitHubContext
 
 	// NOTE: Re-runs are not uniquely identified and can cause run ID collisions.
-	repourl := "https://github.com/" + process.env["GITHUB_REPOSITORY"]
+	repourl := "https://github.com/" + gh.Repository
 
 	stm.Predicate.Builder.Id = repourl
 

--- a/provenance.go
+++ b/provenance.go
@@ -125,12 +125,6 @@ func provgen() Statement {
 	}
 
 	context := AnyContext{}
-	if err := json.Unmarshal([]byte(*githubContext), &context.GitHubContext); err != nil {
-		panic(err)
-	}
-	if err := json.Unmarshal([]byte(*runnerContext), &context.RunnerContext); err != nil {
-		panic(err)
-	}
 
 	gh := context.GitHubContext
 

--- a/provenance.go
+++ b/provenance.go
@@ -129,7 +129,7 @@ func provgen() Statement {
 	gh := context.GitHubContext
 
 	// NOTE: Re-runs are not uniquely identified and can cause run ID collisions.
-	repourl := "https://github.com/" + gh.Repository
+	repourl := "https://github.com/" + process.env["GITHUB_REPOSITORY"]
 
 	stm.Predicate.Builder.Id = repourl
 

--- a/provenance.go
+++ b/provenance.go
@@ -98,7 +98,7 @@ type Completeness struct {
 	Materials   bool `json:"materials"`
 }
 
-func provgen() Statement {
+func provgen(args []string) Statement {
 
 	stm := Statement{PredicateType: "https://slsa.dev/provenance/v0.1", Type: "https://in-toto.io/Statement/v0.1"}
 	//stm.Subject = append(stmt.Subject, generateSubject...)

--- a/provenance.go
+++ b/provenance.go
@@ -12,8 +12,6 @@ var (
 )
 
 const (
-	GitHubHostedIdSuffix = "/Attestations/GitHubHostedActions@v1"
-	SelfHostedIdSuffix   = "/Attestations/SelfHostedActions@v1"
 	TypeId               = "https://github.com/Attestations/arjundashrath/harden-runner@v1"
 	PayloadContentType   = "application/vnd.in-toto+json"
 )
@@ -123,6 +121,7 @@ func provgen() Statement {
 	}
 
 	context := AnyContext{}
+	//TODO THROWS ERROR
 	/*if err := json.Unmarshal([]byte(*githubContext), &context.GitHubContext); err != nil {
 		panic(err)
 	}
@@ -138,6 +137,19 @@ func provgen() Statement {
 	stm.Predicate.Builder.Id = repourl
 
 	stm.Predicate.Metadata.BuildInvocationId = repourl + "/actions/runs/" + gh.RunId
+	
+	stm.Predicate.Recipe.Type = "docker build"
+
+	stm.Predicate.Recipe.DefinedInMaterial = repourl + "/main/blob/Dockerfile"
+	//Path can be taken from core input in case of buildx action
+	
+	argstr := ""
+
+	for _, value := range args {
+		argstr = argstr + value
+	}
+
+	stm.Predicate.Recipe.Arguments = json.RawMessage(argstr)
 
 	return stm
 }

--- a/provenance.go
+++ b/provenance.go
@@ -140,7 +140,9 @@ func provgen(args []string) Statement {
 	
 	stm.Predicate.Recipe.Type = "docker build"
 
-	stm.Predicate.Recipe.DefinedInMaterial = repourl + "/main/blob/Dockerfile"
+	stm.Predicate.Recipe.DefinedInMaterial = 0
+
+	stm.Predicate.Materials[0].URI = repourl + "/main/blob/Dockerfile"
 	//Path can be taken from core input in case of buildx action
 	
 	argstr := ""


### PR DESCRIPTION
@varunsh-coder here are the updates till now,

- The fields that require the GitHub actions data are set, there is just a problem with the GitHub context that throws an error. Once that is fixed, hopefully the data will start showing in the generated provenance

- The provenance is generated at every docker build command, however the problem I identified was that since we generate the provenance when a docker build command is run, the prov is generated before the image is built, and hence the info about the image built cannot be accessed. Need to find a solution to this. Tried waiting/sleeping the go process for sometime to allow the image to be built, did not work as expected.
- Currently it does not support the buildx action, however I figured a lot of values can be taken from the core inputs

I have been following this template, 
```
{
  "_type": "https://in-toto.io/Statement/v0.1",
  "subject": [
    {
      "name": "Docker Image Name",
      "digest": {
        "sha256": "Image Checksum"
      }
    }
  ],
  "predicateType": "https://slsa.dev/provenance/v0.1",
  "predicate": {
    "builder": {
      "id": "GitHub Repo"
    },
    "metadata": {
      "buildInvocationId": "WORKFLOW RUN LINK",
      "completeness": {
        "arguments": true,
        "environment": false,
        "materials": false
      },
      "reproducible": false,
      "buildFinishedOn": "2021-06-15T17:24:42Z"
    },
    "recipe": {
      "type": "Docker build",
      "definedInMaterial": 0,
      "entryPoint": "Docker image entry point",
      "arguments": "Arguments passed to docker build",
      "environment": null
    },
    "materials": [
      {
        "uri": "Dockerfile",
        "digest": {
          "sha1": "Commit Hash if required?"
        }
      }
    ]
  }
}
```
The above format can serve as a guideline for what we need to add in the provenance
 