### PR TITLE
feat: support exempt_files to skip source code overwrite detection

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -137,7 +137,7 @@ func Run(ctx context.Context, configFilePath string, hostDNSServer DNSServer,
 	// start proc mon
 	if cmd == nil {
 		procMon := &ProcessMonitor{CorrelationId: config.CorrelationId, Repo: config.Repo,
-			ApiClient: apiclient, WorkingDirectory: config.WorkingDirectory, DisableFileMonitoring: config.DisableFileMonitoring, DNSProxy: &dnsProxy}
+			ApiClient: apiclient, WorkingDirectory: config.WorkingDirectory, DisableFileMonitoring: config.DisableFileMonitoring, ExemptFiles: config.ExemptFiles, DNSProxy: &dnsProxy}
 		go procMon.MonitorProcesses(errc)
 		WriteLog("started process monitor")
 	}

--- a/config.go
+++ b/config.go
@@ -24,6 +24,7 @@ type config struct {
 	DisableSudo              bool
 	DisableSudoAndContainers bool
 	DisableFileMonitoring    bool
+	ExemptFiles              []string
 	Private                  bool
 }
 
@@ -46,6 +47,7 @@ type configFile struct {
 	DisableSudo              bool   `json:"disable_sudo"`
 	DisableSudoAndContainers bool   `json:"disable_sudo_and_containers"`
 	DisableFileMonitoring    bool   `json:"disable_file_monitoring"`
+	ExemptFiles              string `json:"exempt_files"`
 	Private                  bool   `json:"private"`
 }
 
@@ -77,9 +79,23 @@ func (c *config) init(configFilePath string) error {
 	c.DisableSudo = configFile.DisableSudo
 	c.DisableSudoAndContainers = configFile.DisableSudoAndContainers
 	c.DisableFileMonitoring = configFile.DisableFileMonitoring
+	c.ExemptFiles = parseExemptFiles(configFile.ExemptFiles)
 	c.Private = configFile.Private
 	c.OneTimeKey = configFile.OneTimeKey
 	return nil
+}
+
+// parseExemptFiles splits the exempt_files config value into individual paths.
+// It splits on newlines only so that paths containing spaces are preserved.
+func parseExemptFiles(exemptFiles string) []string {
+	var files []string
+	for _, line := range strings.Split(exemptFiles, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if len(trimmed) > 0 {
+			files = append(files, trimmed)
+		}
+	}
+	return files
 }
 
 func parseEndpoints(allowedEndpoints string) map[string][]Endpoint {

--- a/config_test.go
+++ b/config_test.go
@@ -36,6 +36,30 @@ func Test_config_init(t *testing.T) {
 	}
 }
 
+func Test_parseExemptFiles(t *testing.T) {
+	type args struct {
+		exemptFiles string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{name: "empty", args: args{exemptFiles: ""}, want: nil},
+		{name: "one path per line", args: args{exemptFiles: "dist/index.js\npackage-lock.json"}, want: []string{"dist/index.js", "package-lock.json"}},
+		{name: "trims whitespace and blank lines", args: args{exemptFiles: "  dist/index.js  \n\n  go.sum "}, want: []string{"dist/index.js", "go.sum"}},
+		{name: "preserves spaces within a path", args: args{exemptFiles: "my dir/file.txt\nother.txt"}, want: []string{"my dir/file.txt", "other.txt"}},
+		{name: "handles CRLF", args: args{exemptFiles: "dist/index.js\r\npackage-lock.json\r\n"}, want: []string{"dist/index.js", "package-lock.json"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseExemptFiles(tt.args.exemptFiles); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseExemptFiles() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_parseEndpoints(t *testing.T) {
 	type args struct {
 		allowedEndpoints string

--- a/eventhandler.go
+++ b/eventhandler.go
@@ -28,6 +28,7 @@ type EventHandler struct {
 	ProcessMap              map[string]*Process
 	SourceCodeMap           map[string][]*Event
 	FileOverwriteCounterMap map[string]int // to count file overwrites by an exe
+	ExemptFiles             []string       // files exempted from overwrite detection
 	netMutex                sync.RWMutex
 	fileMutex               sync.RWMutex
 	procMutex               sync.RWMutex
@@ -60,7 +61,7 @@ func (eventHandler *EventHandler) handleFileEvent(event *Event) {
 	// Uncomment to log file writes (only uncomment in INT env)
 	// WriteLog(fmt.Sprintf("file write %s, syscall %s", event.FileName, event.Syscall))
 
-	if isSourceCodeFile(event.FileName) {
+	if isSourceCodeFile(event.FileName) && !eventHandler.isExemptFile(event.FileName) {
 		eventHandler.fileMutex.Lock()
 		defer eventHandler.fileMutex.Unlock()
 
@@ -98,6 +99,19 @@ func isSourceCodeFile(fileName string) bool {
 	// If it has an extension or might be a Dockerfile
 	if strings.Contains(fileName, ".") || strings.Contains(fileName, "Dockerfile") {
 		return true
+	}
+
+	return false
+}
+
+// isExemptFile returns true when the file matches one of the configured exempt
+// paths. Exempt entries are usually repo-relative while events carry absolute
+// paths, so we match on the full path or a trailing path segment.
+func (eventHandler *EventHandler) isExemptFile(fileName string) bool {
+	for _, exempt := range eventHandler.ExemptFiles {
+		if fileName == exempt || strings.HasSuffix(fileName, "/"+exempt) {
+			return true
+		}
 	}
 
 	return false

--- a/eventhandler_test.go
+++ b/eventhandler_test.go
@@ -69,6 +69,32 @@ func TestEventHandler_HandleEvent(t *testing.T) {
 	}
 }
 
+func TestEventHandler_isExemptFile(t *testing.T) {
+	eventHandler := &EventHandler{
+		ExemptFiles: []string{"dist/index.js", "package-lock.json", "my dir/notes.txt"},
+	}
+
+	tests := []struct {
+		name     string
+		fileName string
+		want     bool
+	}{
+		{name: "repo-relative path suffix match", fileName: "/home/runner/work/repo/repo/dist/index.js", want: true},
+		{name: "single filename suffix match", fileName: "/home/runner/work/repo/repo/package-lock.json", want: true},
+		{name: "exact match", fileName: "dist/index.js", want: true},
+		{name: "path with space preserved", fileName: "/home/runner/work/repo/my dir/notes.txt", want: true},
+		{name: "non-exempt file", fileName: "/home/runner/work/repo/repo/src/main.go", want: false},
+		{name: "partial name is not exempted", fileName: "/home/runner/work/repo/repo/not-package-lock.json", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := eventHandler.isExemptFile(tt.fileName); got != tt.want {
+				t.Errorf("isExemptFile(%q) = %v, want %v", tt.fileName, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetContainerIdByPid(t *testing.T) {
 	type args struct {
 		cgroupPath string

--- a/procmon.go
+++ b/procmon.go
@@ -20,6 +20,7 @@ type ProcessMonitor struct {
 	DNSProxy              *DNSProxy
 	WorkingDirectory      string
 	DisableFileMonitoring bool
+	ExemptFiles           []string
 	Events                map[int]*Event
 	mutex                 sync.RWMutex
 }

--- a/procmon_linux.go
+++ b/procmon_linux.go
@@ -153,7 +153,7 @@ func (p *ProcessMonitor) MonitorProcesses(errc chan error) {
 func (p *ProcessMonitor) receive(r *libaudit.AuditClient) error {
 
 	p.Events = make(map[int]*Event)
-	eventHandler := EventHandler{CorrelationId: p.CorrelationId, Repo: p.Repo, ApiClient: p.ApiClient, DNSProxy: p.DNSProxy}
+	eventHandler := EventHandler{CorrelationId: p.CorrelationId, Repo: p.Repo, ApiClient: p.ApiClient, DNSProxy: p.DNSProxy, ExemptFiles: p.ExemptFiles}
 	eventHandler.ProcessConnectionMap = make(map[string]bool)
 	eventHandler.ProcessFileMap = make(map[string]bool)
 	eventHandler.SourceCodeMap = make(map[string][]*Event)


### PR DESCRIPTION
## Summary

Honors a new `exempt_files` config value so that specific files can be excluded from source code overwrite detection, while file monitoring stays enabled for everything else.

## Problem

Source code overwrite detection currently applies to every source file under the working directory. The only way to quiet it for expected writes (for example generated bundles or lock files) is `disable_file_monitoring`, which disables monitoring for the whole job. There was no way to exempt individual files.

This is the agent side of step-security/harden-runner#330. The action change that surfaces the `exempt-files` input and sends `exempt_files` in the agent config is in step-security/harden-runner#678.

## Fix

- Parse the newline-separated `exempt_files` value from the agent config into a list of paths (`parseExemptFiles`). Splitting on newlines only keeps paths that contain spaces intact.
- Thread the list from `config` through `ProcessMonitor` to `EventHandler`.
- In `handleFileEvent`, skip source code overwrite tracking for a file when it matches an exempt path. Exempt entries are usually repo-relative while events carry absolute paths, so matching is done on the full path or a trailing path segment.

When `exempt_files` is empty (the default) behavior is unchanged.

### Files changed

| File | Change |
|------|--------|
| `config.go` | Parse `exempt_files` into `[]string` via `parseExemptFiles` |
| `procmon.go` | Add `ExemptFiles` to `ProcessMonitor` |
| `agent.go` | Pass `ExemptFiles` from config to the monitor |
| `procmon_linux.go` | Pass `ExemptFiles` into the `EventHandler` |
| `eventhandler.go` | Add `isExemptFile` and skip overwrite detection for exempt files |

### Testing

- `go test ./...` — added `Test_parseExemptFiles` (newline handling, CRLF, blank lines, spaces in paths) and `TestEventHandler_isExemptFile` (exact, suffix, space-in-path, and negative matches)
- `gofmt`

Related to step-security/harden-runner#330
Companion action PR: step-security/harden-runner#678
