### PR TITLE
fix: revoke sudo before Docker teardown

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -113,6 +113,21 @@ func Run(ctx context.Context, configFilePath string, hostDNSServer DNSServer,
 		}
 	}
 
+	sudo := Sudo{}
+
+	// Revoke sudo and container access as early as possible — only the parsed
+	// config and temp dir are prerequisites. Container teardown runs in the
+	// background inside disableSudoAndContainers; job steps must not get a
+	// window to run `sudo` while DNS/firewall setup is still in progress.
+	if config.DisableSudoAndContainers {
+		err := sudo.disableSudoAndContainers(tempDir)
+		if err != nil {
+			WriteLog(fmt.Sprintf("%s Unable to disable sudo and docker %v", StepSecurityAnnotationPrefix, err))
+		} else {
+			WriteLog("disabled sudo and docker")
+		}
+	}
+
 	Cache := InitCache(config.EgressPolicy)
 
 	allowedEndpoints, wildcardEndpoints := addImplicitEndpoints(config.Endpoints, config.DisableTelemetry, globalBlocklist)
@@ -143,12 +158,7 @@ func Run(ctx context.Context, configFilePath string, hostDNSServer DNSServer,
 	}
 
 	dnsConfig := DnsConfig{}
-	sudo := Sudo{}
 	var ipAddressEndpoints []ipAddressEndpoint
-
-	if config.DisableSudoAndContainers {
-		go sudo.uninstallDocker()
-	}
 
 	// hydrate dns cache
 	if config.EgressPolicy == EgressPolicyBlock {
@@ -280,15 +290,6 @@ func Run(ctx context.Context, configFilePath string, hostDNSServer DNSServer,
 			if IsCustomDetectionRulesEnabled() {
 				WriteLog("[armour] Custom detection rules enabled")
 			}
-		}
-	}
-
-	if config.DisableSudoAndContainers {
-		err := sudo.disableSudoAndContainers(tempDir)
-		if err != nil {
-			WriteLog(fmt.Sprintf("%s Unable to disable sudo and docker %v", StepSecurityAnnotationPrefix, err))
-		} else {
-			WriteLog("disabled sudo and docker")
 		}
 	}
 

--- a/sudo.go
+++ b/sudo.go
@@ -13,10 +13,17 @@ type Sudo struct {
 	SudoersBackUpPath string
 }
 
-const (
-	sudoersFile = "/etc/sudoers.d/runner"
-	runnerUser  = "runner"
-)
+// sudoersFile is a var so tests can point it at a temp file
+var sudoersFile = "/etc/sudoers.d/runner"
+
+const runnerUser = "runner"
+
+// runCmd is a var so tests can inject a fake command runner
+var runCmd = run
+
+// socket paths are vars so tests can point them at temp files
+var dockerSockPath = "/var/run/docker.sock"
+var containerdSockPath = "/run/containerd/containerd.sock"
 
 func (s *Sudo) disableSudo(tempDir string) error {
 	s.SudoersBackUpPath = path.Join(tempDir, "runner")
@@ -47,17 +54,27 @@ func (s *Sudo) revertDisableSudo() error {
 
 func (s *Sudo) disableSudoAndContainers(tempDir string) error {
 
-	s.removeDockerDirectoriesAndFiles()
-
-	// Remove socket permissions if they exist
-	s.removeSocketPermissions()
 	var errstrings []string
 
+	// Revoke sudo first: a single truncate syscall. This must happen before
+	// any container teardown — the teardown takes several seconds and job
+	// steps can start (and run `sudo`) while it is still in progress.
 	err := s.disableSudo(tempDir)
 	if err != nil {
 		WriteLog(fmt.Sprintf("error disabling sudo: %v", err))
 		errstrings = append(errstrings, err.Error())
 	}
+
+	// Revoke container access second: chmod on the sockets, also instant.
+	s.removeSocketPermissions()
+
+	// Slow cleanup runs in the background — it is not enforcement and must
+	// not delay it. Purge first (stops the daemon, unmounts overlays), then
+	// delete the directories; racing the two makes the delete far slower.
+	go func() {
+		s.uninstallDocker()
+		s.removeDockerDirectoriesAndFiles()
+	}()
 
 	//flatten errs
 	if len(errstrings) > 0 {
@@ -69,19 +86,15 @@ func (s *Sudo) disableSudoAndContainers(tempDir string) error {
 // removeSocketPermissions removes permissions from Docker and containerd sockets if they exist
 func (s *Sudo) removeSocketPermissions() {
 	// Check and remove docker.sock permissions if it exists
-	if _, err := os.Stat("/var/run/docker.sock"); err == nil {
-		cmd := exec.Command("sudo", "chmod", "000", "/var/run/docker.sock")
-		err := cmd.Run()
-		if err != nil {
+	if _, err := os.Stat(dockerSockPath); err == nil {
+		if err := os.Chmod(dockerSockPath, 0000); err != nil {
 			WriteLog(fmt.Sprintf("error removing docker.sock permissions: %v", err))
 		}
 	}
 
 	// Check and remove containerd.sock permissions if it exists
-	if _, err := os.Stat("/run/containerd/containerd.sock"); err == nil {
-		cmd := exec.Command("sudo", "chmod", "000", "/run/containerd/containerd.sock")
-		err := cmd.Run()
-		if err != nil {
+	if _, err := os.Stat(containerdSockPath); err == nil {
+		if err := os.Chmod(containerdSockPath, 0000); err != nil {
 			WriteLog(fmt.Sprintf("error removing containerd.sock permissions: %v", err))
 		}
 	}
@@ -120,15 +133,15 @@ func run(cmd string, args ...string) {
 
 func (s *Sudo) uninstallDocker() error {
 	WriteLog("Uninstalling docker")
-	run("sudo", "apt-get", "purge", "-y",
+	runCmd("apt-get", "purge", "-y",
 		"docker-ce", "docker-ce-cli", "containerd.io")
 	return nil
 }
 
 func (s *Sudo) removeDockerDirectoriesAndFiles() error {
-	run("sudo", "rm", "-rf", "/var/lib/docker")
-	run("sudo", "rm", "-rf", "/var/lib/containerd")
-	run("sudo", "rm", "-f", "/etc/apt/sources.list.d/docker.list")
-	run("sudo", "rm", "-f", "/etc/apt/keyrings/docker.asc")
+	runCmd("rm", "-rf", "/var/lib/docker")
+	runCmd("rm", "-rf", "/var/lib/containerd")
+	runCmd("rm", "-f", "/etc/apt/sources.list.d/docker.list")
+	runCmd("rm", "-f", "/etc/apt/keyrings/docker.asc")
 	return nil
 }

--- a/sudo.go
+++ b/sudo.go
@@ -11,21 +11,49 @@ import (
 
 type Sudo struct {
 	SudoersBackUpPath string
-}
 
-// sudoersFile is a var so tests can point it at a temp file
-var sudoersFile = "/etc/sudoers.d/runner"
+	// test seams; zero values fall back to the real paths and command runner.
+	// These are per-instance fields rather than package vars so the background
+	// container-cleanup goroutine never reads state a test restores later.
+	sudoersFilePathOverride string
+	dockerSockPathOverride  string
+	containerdSockOverride  string
+	runCmd                  func(cmd string, args ...string)
+}
 
 const runnerUser = "runner"
 
-// runCmd is a var so tests can inject a fake command runner
-var runCmd = run
+func (s *Sudo) sudoersFilePath() string {
+	if s.sudoersFilePathOverride != "" {
+		return s.sudoersFilePathOverride
+	}
+	return "/etc/sudoers.d/runner"
+}
 
-// socket paths are vars so tests can point them at temp files
-var dockerSockPath = "/var/run/docker.sock"
-var containerdSockPath = "/run/containerd/containerd.sock"
+func (s *Sudo) dockerSockPath() string {
+	if s.dockerSockPathOverride != "" {
+		return s.dockerSockPathOverride
+	}
+	return "/var/run/docker.sock"
+}
+
+func (s *Sudo) containerdSockPath() string {
+	if s.containerdSockOverride != "" {
+		return s.containerdSockOverride
+	}
+	return "/run/containerd/containerd.sock"
+}
+
+func (s *Sudo) exec(cmd string, args ...string) {
+	if s.runCmd != nil {
+		s.runCmd(cmd, args...)
+		return
+	}
+	run(cmd, args...)
+}
 
 func (s *Sudo) disableSudo(tempDir string) error {
+	sudoersFile := s.sudoersFilePath()
 	s.SudoersBackUpPath = path.Join(tempDir, "runner")
 	err := copy(sudoersFile, s.SudoersBackUpPath)
 
@@ -42,7 +70,7 @@ func (s *Sudo) disableSudo(tempDir string) error {
 
 func (s *Sudo) revertDisableSudo() error {
 	if len(s.SudoersBackUpPath) > 0 {
-		err := copy(s.SudoersBackUpPath, sudoersFile)
+		err := copy(s.SudoersBackUpPath, s.sudoersFilePath())
 
 		if err != nil {
 			return fmt.Errorf("error reverting sudoers file: %v", err)
@@ -86,15 +114,15 @@ func (s *Sudo) disableSudoAndContainers(tempDir string) error {
 // removeSocketPermissions removes permissions from Docker and containerd sockets if they exist
 func (s *Sudo) removeSocketPermissions() {
 	// Check and remove docker.sock permissions if it exists
-	if _, err := os.Stat(dockerSockPath); err == nil {
-		if err := os.Chmod(dockerSockPath, 0000); err != nil {
+	if _, err := os.Stat(s.dockerSockPath()); err == nil {
+		if err := os.Chmod(s.dockerSockPath(), 0000); err != nil {
 			WriteLog(fmt.Sprintf("error removing docker.sock permissions: %v", err))
 		}
 	}
 
 	// Check and remove containerd.sock permissions if it exists
-	if _, err := os.Stat(containerdSockPath); err == nil {
-		if err := os.Chmod(containerdSockPath, 0000); err != nil {
+	if _, err := os.Stat(s.containerdSockPath()); err == nil {
+		if err := os.Chmod(s.containerdSockPath(), 0000); err != nil {
 			WriteLog(fmt.Sprintf("error removing containerd.sock permissions: %v", err))
 		}
 	}
@@ -133,15 +161,15 @@ func run(cmd string, args ...string) {
 
 func (s *Sudo) uninstallDocker() error {
 	WriteLog("Uninstalling docker")
-	runCmd("apt-get", "purge", "-y",
+	s.exec("apt-get", "purge", "-y",
 		"docker-ce", "docker-ce-cli", "containerd.io")
 	return nil
 }
 
 func (s *Sudo) removeDockerDirectoriesAndFiles() error {
-	runCmd("rm", "-rf", "/var/lib/docker")
-	runCmd("rm", "-rf", "/var/lib/containerd")
-	runCmd("rm", "-f", "/etc/apt/sources.list.d/docker.list")
-	runCmd("rm", "-f", "/etc/apt/keyrings/docker.asc")
+	s.exec("rm", "-rf", "/var/lib/docker")
+	s.exec("rm", "-rf", "/var/lib/containerd")
+	s.exec("rm", "-f", "/etc/apt/sources.list.d/docker.list")
+	s.exec("rm", "-f", "/etc/apt/keyrings/docker.asc")
 	return nil
 }

--- a/sudo_test.go
+++ b/sudo_test.go
@@ -11,34 +11,29 @@ import (
 
 const testSudoersContent = "runner ALL=(ALL) NOPASSWD:ALL\n"
 
-func setupFakeSudoers(t *testing.T) string {
+// newTestSudo returns a Sudo wired to a fake sudoers file and non-existent
+// socket paths so tests never touch the machine's real sudoers or sockets.
+// All seams are per-instance fields: the background container-cleanup
+// goroutine may outlive the test, so it must never read package-level state
+// that a test cleanup restores.
+func newTestSudo(t *testing.T, runCmd func(cmd string, args ...string)) (*Sudo, string) {
 	t.Helper()
-	origSudoers := sudoersFile
-	sudoersFile = path.Join(t.TempDir(), "runner")
-	t.Cleanup(func() { sudoersFile = origSudoers })
-
-	redirectSocketPaths(t)
+	dir := t.TempDir()
+	sudoersPath := path.Join(dir, "runner")
 	// 0640 rather than the real file's 0440: the agent truncates as root
 	// (which bypasses permission checks), but tests run unprivileged.
-	if err := os.WriteFile(sudoersFile, []byte(testSudoersContent), 0640); err != nil {
+	if err := os.WriteFile(sudoersPath, []byte(testSudoersContent), 0640); err != nil {
 		t.Fatalf("failed to create fake sudoers file: %v", err)
 	}
-	return sudoersFile
-}
-
-// redirectSocketPaths points socket paths at non-existent temp files so tests
-// never chmod the machine's real docker/containerd sockets.
-func redirectSocketPaths(t *testing.T) {
-	t.Helper()
-	origDocker, origContainerd := dockerSockPath, containerdSockPath
-	dockerSockPath = path.Join(t.TempDir(), "no-such-docker.sock")
-	containerdSockPath = path.Join(t.TempDir(), "no-such-containerd.sock")
-	t.Cleanup(func() { dockerSockPath, containerdSockPath = origDocker, origContainerd })
+	return &Sudo{
+		sudoersFilePathOverride: sudoersPath,
+		dockerSockPathOverride:  path.Join(dir, "no-such-docker.sock"),
+		containerdSockOverride:  path.Join(dir, "no-such-containerd.sock"),
+		runCmd:                  runCmd,
+	}, sudoersPath
 }
 
 func Test_disableSudoAndContainers_RevokesSudoBeforeContainerCleanup(t *testing.T) {
-	setupFakeSudoers(t)
-
 	type observed struct {
 		command     string
 		sudoersSize int64
@@ -49,11 +44,11 @@ func Test_disableSudoAndContainers_RevokesSudoBeforeContainerCleanup(t *testing.
 	var mu sync.Mutex
 	var commands []string
 
-	origRun := runCmd
-	runCmd = func(cmd string, args ...string) {
+	sudo, sudoersPath := newTestSudo(t, nil)
+	sudo.runCmd = func(cmd string, args ...string) {
 		full := strings.Join(append([]string{cmd}, args...), " ")
 		var size int64 = -1
-		if fi, err := os.Stat(sudoersFile); err == nil {
+		if fi, err := os.Stat(sudoersPath); err == nil {
 			size = fi.Size()
 		}
 		mu.Lock()
@@ -65,12 +60,8 @@ func Test_disableSudoAndContainers_RevokesSudoBeforeContainerCleanup(t *testing.
 		}
 		<-release
 	}
-	t.Cleanup(func() {
-		close(release)
-		runCmd = origRun
-	})
+	t.Cleanup(func() { close(release) })
 
-	sudo := &Sudo{}
 	done := make(chan error, 1)
 	go func() {
 		done <- sudo.disableSudoAndContainers(t.TempDir())
@@ -87,7 +78,7 @@ func Test_disableSudoAndContainers_RevokesSudoBeforeContainerCleanup(t *testing.
 		t.Fatal("disableSudoAndContainers blocked on container teardown; sudo revocation must complete first")
 	}
 
-	fi, err := os.Stat(sudoersFile)
+	fi, err := os.Stat(sudoersPath)
 	if err != nil {
 		t.Fatalf("failed to stat sudoers file: %v", err)
 	}
@@ -112,16 +103,14 @@ func Test_disableSudoAndContainers_RevokesSudoBeforeContainerCleanup(t *testing.
 }
 
 func Test_disableSudoAndContainers_ErrorSurfacesWhenSudoersMissing(t *testing.T) {
-	origSudoers := sudoersFile
-	sudoersFile = path.Join(t.TempDir(), "does-not-exist")
-	t.Cleanup(func() { sudoersFile = origSudoers })
-	redirectSocketPaths(t)
+	dir := t.TempDir()
+	sudo := &Sudo{
+		sudoersFilePathOverride: path.Join(dir, "does-not-exist"),
+		dockerSockPathOverride:  path.Join(dir, "no-such-docker.sock"),
+		containerdSockOverride:  path.Join(dir, "no-such-containerd.sock"),
+		runCmd:                  func(cmd string, args ...string) {},
+	}
 
-	origRun := runCmd
-	runCmd = func(cmd string, args ...string) {}
-	t.Cleanup(func() { runCmd = origRun })
-
-	sudo := &Sudo{}
 	err := sudo.disableSudoAndContainers(t.TempDir())
 	if err == nil {
 		t.Fatal("expected error when sudoers backup fails, got nil")
@@ -133,30 +122,23 @@ func Test_disableSudoAndContainers_ErrorSurfacesWhenSudoersMissing(t *testing.T)
 
 // Socket permissions must be revoked synchronously (before return), via chmod.
 func Test_disableSudoAndContainers_RemovesSocketPermissions(t *testing.T) {
-	setupFakeSudoers(t)
+	sudo, _ := newTestSudo(t, func(cmd string, args ...string) {})
 
 	sockDir := t.TempDir()
-	origDocker, origContainerd := dockerSockPath, containerdSockPath
-	dockerSockPath = path.Join(sockDir, "docker.sock")
-	containerdSockPath = path.Join(sockDir, "containerd.sock")
-	t.Cleanup(func() { dockerSockPath, containerdSockPath = origDocker, origContainerd })
+	sudo.dockerSockPathOverride = path.Join(sockDir, "docker.sock")
+	sudo.containerdSockOverride = path.Join(sockDir, "containerd.sock")
 
-	for _, p := range []string{dockerSockPath, containerdSockPath} {
+	for _, p := range []string{sudo.dockerSockPathOverride, sudo.containerdSockOverride} {
 		if err := os.WriteFile(p, nil, 0660); err != nil {
 			t.Fatalf("failed to create fake socket %s: %v", p, err)
 		}
 	}
 
-	origRun := runCmd
-	runCmd = func(cmd string, args ...string) {}
-	t.Cleanup(func() { runCmd = origRun })
-
-	sudo := &Sudo{}
 	if err := sudo.disableSudoAndContainers(t.TempDir()); err != nil {
 		t.Fatalf("disableSudoAndContainers returned error: %v", err)
 	}
 
-	for _, p := range []string{dockerSockPath, containerdSockPath} {
+	for _, p := range []string{sudo.dockerSockPathOverride, sudo.containerdSockOverride} {
 		fi, err := os.Stat(p)
 		if err != nil {
 			t.Fatalf("failed to stat %s: %v", p, err)
@@ -168,9 +150,8 @@ func Test_disableSudoAndContainers_RemovesSocketPermissions(t *testing.T) {
 }
 
 func Test_disableSudo_BackupAndRevert(t *testing.T) {
-	setupFakeSudoers(t)
+	sudo, sudoersPath := newTestSudo(t, func(cmd string, args ...string) {})
 
-	sudo := &Sudo{}
 	tempDir := t.TempDir()
 	if err := sudo.disableSudo(tempDir); err != nil {
 		t.Fatalf("disableSudo returned error: %v", err)
@@ -184,7 +165,7 @@ func Test_disableSudo_BackupAndRevert(t *testing.T) {
 		t.Fatalf("backup content = %q, want %q", string(backup), testSudoersContent)
 	}
 
-	fi, err := os.Stat(sudoersFile)
+	fi, err := os.Stat(sudoersPath)
 	if err != nil {
 		t.Fatalf("failed to stat sudoers file: %v", err)
 	}
@@ -195,7 +176,7 @@ func Test_disableSudo_BackupAndRevert(t *testing.T) {
 	if err := sudo.revertDisableSudo(); err != nil {
 		t.Fatalf("revertDisableSudo returned error: %v", err)
 	}
-	restored, err := os.ReadFile(sudoersFile)
+	restored, err := os.ReadFile(sudoersPath)
 	if err != nil {
 		t.Fatalf("failed to read restored sudoers file: %v", err)
 	}

--- a/sudo_test.go
+++ b/sudo_test.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"os"
+	"path"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+const testSudoersContent = "runner ALL=(ALL) NOPASSWD:ALL\n"
+
+func setupFakeSudoers(t *testing.T) string {
+	t.Helper()
+	origSudoers := sudoersFile
+	sudoersFile = path.Join(t.TempDir(), "runner")
+	t.Cleanup(func() { sudoersFile = origSudoers })
+
+	redirectSocketPaths(t)
+	// 0640 rather than the real file's 0440: the agent truncates as root
+	// (which bypasses permission checks), but tests run unprivileged.
+	if err := os.WriteFile(sudoersFile, []byte(testSudoersContent), 0640); err != nil {
+		t.Fatalf("failed to create fake sudoers file: %v", err)
+	}
+	return sudoersFile
+}
+
+// redirectSocketPaths points socket paths at non-existent temp files so tests
+// never chmod the machine's real docker/containerd sockets.
+func redirectSocketPaths(t *testing.T) {
+	t.Helper()
+	origDocker, origContainerd := dockerSockPath, containerdSockPath
+	dockerSockPath = path.Join(t.TempDir(), "no-such-docker.sock")
+	containerdSockPath = path.Join(t.TempDir(), "no-such-containerd.sock")
+	t.Cleanup(func() { dockerSockPath, containerdSockPath = origDocker, origContainerd })
+}
+
+func Test_disableSudoAndContainers_RevokesSudoBeforeContainerCleanup(t *testing.T) {
+	setupFakeSudoers(t)
+
+	type observed struct {
+		command     string
+		sudoersSize int64
+	}
+
+	firstCmd := make(chan observed, 1)
+	release := make(chan struct{})
+	var mu sync.Mutex
+	var commands []string
+
+	origRun := runCmd
+	runCmd = func(cmd string, args ...string) {
+		full := strings.Join(append([]string{cmd}, args...), " ")
+		var size int64 = -1
+		if fi, err := os.Stat(sudoersFile); err == nil {
+			size = fi.Size()
+		}
+		mu.Lock()
+		commands = append(commands, full)
+		mu.Unlock()
+		select {
+		case firstCmd <- observed{command: full, sudoersSize: size}:
+		default:
+		}
+		<-release
+	}
+	t.Cleanup(func() {
+		close(release)
+		runCmd = origRun
+	})
+
+	sudo := &Sudo{}
+	done := make(chan error, 1)
+	go func() {
+		done <- sudo.disableSudoAndContainers(t.TempDir())
+	}()
+
+	// Sudo revocation must not wait on container teardown, which is
+	// simulated here by a command runner that blocks forever.
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("disableSudoAndContainers returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("disableSudoAndContainers blocked on container teardown; sudo revocation must complete first")
+	}
+
+	fi, err := os.Stat(sudoersFile)
+	if err != nil {
+		t.Fatalf("failed to stat sudoers file: %v", err)
+	}
+	if fi.Size() != 0 {
+		t.Fatalf("sudoers file not truncated after disableSudoAndContainers returned; size = %d", fi.Size())
+	}
+
+	// The first container-cleanup command must observe an already-truncated
+	// sudoers file, and must be the package purge (daemon stop) rather than
+	// a directory delete.
+	select {
+	case obs := <-firstCmd:
+		if obs.sudoersSize != 0 {
+			t.Fatalf("first container-cleanup command %q ran before sudoers truncate; observed size = %d", obs.command, obs.sudoersSize)
+		}
+		if !strings.HasPrefix(obs.command, "apt-get purge") {
+			t.Fatalf("first container-cleanup command = %q, want package purge before directory deletion", obs.command)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no container-cleanup command observed")
+	}
+}
+
+func Test_disableSudoAndContainers_ErrorSurfacesWhenSudoersMissing(t *testing.T) {
+	origSudoers := sudoersFile
+	sudoersFile = path.Join(t.TempDir(), "does-not-exist")
+	t.Cleanup(func() { sudoersFile = origSudoers })
+	redirectSocketPaths(t)
+
+	origRun := runCmd
+	runCmd = func(cmd string, args ...string) {}
+	t.Cleanup(func() { runCmd = origRun })
+
+	sudo := &Sudo{}
+	err := sudo.disableSudoAndContainers(t.TempDir())
+	if err == nil {
+		t.Fatal("expected error when sudoers backup fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "error disabling sudo and containers") {
+		t.Fatalf("error = %q, want it to contain %q", err.Error(), "error disabling sudo and containers")
+	}
+}
+
+// Socket permissions must be revoked synchronously (before return), via chmod.
+func Test_disableSudoAndContainers_RemovesSocketPermissions(t *testing.T) {
+	setupFakeSudoers(t)
+
+	sockDir := t.TempDir()
+	origDocker, origContainerd := dockerSockPath, containerdSockPath
+	dockerSockPath = path.Join(sockDir, "docker.sock")
+	containerdSockPath = path.Join(sockDir, "containerd.sock")
+	t.Cleanup(func() { dockerSockPath, containerdSockPath = origDocker, origContainerd })
+
+	for _, p := range []string{dockerSockPath, containerdSockPath} {
+		if err := os.WriteFile(p, nil, 0660); err != nil {
+			t.Fatalf("failed to create fake socket %s: %v", p, err)
+		}
+	}
+
+	origRun := runCmd
+	runCmd = func(cmd string, args ...string) {}
+	t.Cleanup(func() { runCmd = origRun })
+
+	sudo := &Sudo{}
+	if err := sudo.disableSudoAndContainers(t.TempDir()); err != nil {
+		t.Fatalf("disableSudoAndContainers returned error: %v", err)
+	}
+
+	for _, p := range []string{dockerSockPath, containerdSockPath} {
+		fi, err := os.Stat(p)
+		if err != nil {
+			t.Fatalf("failed to stat %s: %v", p, err)
+		}
+		if fi.Mode().Perm() != 0 {
+			t.Fatalf("%s permissions not removed: %v", p, fi.Mode().Perm())
+		}
+	}
+}
+
+func Test_disableSudo_BackupAndRevert(t *testing.T) {
+	setupFakeSudoers(t)
+
+	sudo := &Sudo{}
+	tempDir := t.TempDir()
+	if err := sudo.disableSudo(tempDir); err != nil {
+		t.Fatalf("disableSudo returned error: %v", err)
+	}
+
+	backup, err := os.ReadFile(sudo.SudoersBackUpPath)
+	if err != nil {
+		t.Fatalf("failed to read backup: %v", err)
+	}
+	if string(backup) != testSudoersContent {
+		t.Fatalf("backup content = %q, want %q", string(backup), testSudoersContent)
+	}
+
+	fi, err := os.Stat(sudoersFile)
+	if err != nil {
+		t.Fatalf("failed to stat sudoers file: %v", err)
+	}
+	if fi.Size() != 0 {
+		t.Fatalf("sudoers file not truncated; size = %d", fi.Size())
+	}
+
+	if err := sudo.revertDisableSudo(); err != nil {
+		t.Fatalf("revertDisableSudo returned error: %v", err)
+	}
+	restored, err := os.ReadFile(sudoersFile)
+	if err != nil {
+		t.Fatalf("failed to read restored sudoers file: %v", err)
+	}
+	if string(restored) != testSudoersContent {
+		t.Fatalf("restored content = %q, want %q", string(restored), testSudoersContent)
+	}
+}


### PR DESCRIPTION
Call disableSudoAndContainers early in agent startup and revoke sudo and socket permissions before the slow container cleanup, which now runs in the background. Add tests for revocation order and socket perms.