### PR TITLE
feat: fetch GitHub Actions domains from meta API

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -115,7 +115,17 @@ func Run(ctx context.Context, configFilePath string, hostDNSServer DNSServer,
 
 	Cache := InitCache(config.EgressPolicy)
 
-	allowedEndpoints, wildcardEndpoints := addImplicitEndpoints(config.Endpoints, config.DisableTelemetry, globalBlocklist)
+	// Fetch GitHub Actions domains from the meta API. On failure the
+	// hardcoded implicit endpoints remain the baseline.
+	githubMetaDomains, err := apiclient.getGithubMetaDomains()
+	if err != nil {
+		WriteLog(fmt.Sprintf("Error fetching GitHub meta domains: %v", err))
+	} else {
+		WriteLog(fmt.Sprintf("fetched GitHub meta domains: %+v", githubMetaDomains))
+		WriteLog("\n")
+	}
+
+	allowedEndpoints, wildcardEndpoints := addImplicitEndpoints(config.Endpoints, config.DisableTelemetry, globalBlocklist, githubMetaDomains)
 
 	// Start DNS servers and get confirmation
 	dnsProxy := DNSProxy{
@@ -371,7 +381,7 @@ func refreshDNSEntries(ctx context.Context, iptables *Firewall, blocklist *Globa
 
 }
 
-func addImplicitEndpoints(endpoints map[string][]Endpoint, disableTelemetry bool, blocklist *GlobalBlocklist) (map[string][]Endpoint, map[string][]Endpoint) {
+func addImplicitEndpoints(endpoints map[string][]Endpoint, disableTelemetry bool, blocklist *GlobalBlocklist, githubMetaDomains []Endpoint) (map[string][]Endpoint, map[string][]Endpoint) {
 
 	normalEndpoints := make(map[string][]Endpoint)
 	wildcardEndpoints := make(map[string][]Endpoint)
@@ -383,6 +393,10 @@ func addImplicitEndpoints(endpoints map[string][]Endpoint, disableTelemetry bool
 		{domainName: "actions-results-receiver-production.githubapp.com", port: 443}, // GitHub
 		{domainName: "productionresultssa*.blob.core.windows.net.", port: 443},       // GitHub
 	}
+
+	// GitHub Actions domains fetched from the meta API; empty if the fetch
+	// failed, in which case the hardcoded list above is the baseline.
+	implicitEndpoints = append(implicitEndpoints, githubMetaDomains...)
 
 	for key, val := range endpoints {
 		if isWildcardDomain(key) {

--- a/agent_test.go
+++ b/agent_test.go
@@ -258,7 +258,7 @@ func Test_addImplicitEndpoints_RemovesGlobalBlocklistedEndpoints(t *testing.T) {
 		"*.example.com.":           {{domainName: "*.example.com.", port: 443}},
 	}
 
-	filteredAllowedEndpoints, filteredWildcardEndpoints := addImplicitEndpoints(endpoints, true, globalBlocklist)
+	filteredAllowedEndpoints, filteredWildcardEndpoints := addImplicitEndpoints(endpoints, true, globalBlocklist, nil)
 
 	if _, found := filteredAllowedEndpoints["allowed.com."]; found {
 		t.Fatalf("expected allowed.com to be removed")
@@ -274,6 +274,33 @@ func Test_addImplicitEndpoints_RemovesGlobalBlocklistedEndpoints(t *testing.T) {
 
 	if _, found := filteredWildcardEndpoints["*.example.com."]; !found {
 		t.Fatalf("expected *.example.com to remain")
+	}
+}
+
+func Test_addImplicitEndpoints_AddsGithubMetaDomains(t *testing.T) {
+	githubMetaDomains := []Endpoint{
+		{domainName: "release-assets.github.com", port: 443},
+		{domainName: "*.pkg.github.com", port: 443},
+		{domainName: "blocklisted.github.io", port: 443},
+	}
+
+	globalBlocklist := NewGlobalBlocklist(&GlobalBlocklistResponse{
+		Domains: []CompromisedEndpoint{{Endpoint: "blocklisted.github.io", Reason: "blocked"}},
+	})
+
+	allowedEndpoints, wildcardEndpoints := addImplicitEndpoints(map[string][]Endpoint{}, true, globalBlocklist, githubMetaDomains)
+
+	if _, found := allowedEndpoints["release-assets.github.com"]; !found {
+		t.Fatalf("expected meta domain release-assets.github.com to be added")
+	}
+
+	if _, found := wildcardEndpoints["*.pkg.github.com"]; !found {
+		t.Fatalf("expected wildcard meta domain *.pkg.github.com to be added")
+	}
+
+	// Global blocklist filtering must still apply to meta domains
+	if _, found := allowedEndpoints["blocklisted.github.io"]; found {
+		t.Fatalf("expected blocklisted meta domain to be removed")
 	}
 }
 

--- a/apiclient.go
+++ b/apiclient.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strings"
 	"time"
 )
 
@@ -191,6 +192,65 @@ func (apiclient *ApiClient) getGlobalBlocklist() (*GlobalBlocklistResponse, erro
 	}
 
 	return out, nil
+}
+
+type GithubMetaResponse struct {
+	Domains struct {
+		Actions []string `json:"actions"`
+	} `json:"domains"`
+}
+
+// getGithubMetaDomains fetches the GitHub Actions domains from the meta API.
+// Domains under githubusercontent.com are skipped since they are already
+// covered by the hardcoded wildcard implicit endpoints.
+func (apiclient *ApiClient) getGithubMetaDomains() ([]Endpoint, error) {
+	url := fmt.Sprintf("%s/github/meta", apiclient.APIURL)
+
+	maxRetries := 3
+	var lastErr error
+
+	for i := 0; i < maxRetries; i++ {
+		if i > 0 {
+			time.Sleep(500 * time.Millisecond)
+		}
+
+		resp, err := apiclient.Client.Get(url)
+		if err != nil {
+			lastErr = fmt.Errorf("[getGithubMetaDomains] error while sending request: %s", err)
+			continue
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			lastErr = fmt.Errorf("[getGithubMetaDomains] response status not okay: status %d", resp.StatusCode)
+			continue
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			lastErr = fmt.Errorf("[getGithubMetaDomains] unable to read response body: %s", err)
+			continue
+		}
+
+		var meta GithubMetaResponse
+		if err := json.Unmarshal(body, &meta); err != nil {
+			lastErr = fmt.Errorf("[getGithubMetaDomains] unable to unmarshal response body: %s", err)
+			continue
+		}
+
+		var endpoints []Endpoint
+		for _, domain := range meta.Domains.Actions {
+			if strings.HasSuffix(domain, "githubusercontent.com") {
+				continue
+			}
+			endpoints = append(endpoints, Endpoint{domainName: domain, port: 443})
+		}
+
+		return endpoints, nil
+	}
+
+	return nil, fmt.Errorf("failed to fetch GitHub meta domains after %d retries: %v", maxRetries, lastErr)
 }
 
 func (apiclient *ApiClient) sendApiRequest(method, url string, body interface{}) error {

--- a/apiclient_test.go
+++ b/apiclient_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// newTestHTTPClient uses an explicit transport so these tests keep working
+// even after another test has mocked http.DefaultTransport via httpmock.
+func newTestHTTPClient() *http.Client {
+	return &http.Client{Timeout: 3 * time.Second, Transport: &http.Transport{}}
+}
+
+func Test_getGithubMetaDomains(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/github/meta" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		fmt.Fprint(w, `{"domains":{"actions":["github.com","api.github.com","codeload.github.com","*.actions.githubusercontent.com","objects.githubusercontent.com"]}}`)
+	}))
+	defer server.Close()
+
+	apiclient := &ApiClient{Client: newTestHTTPClient(), APIURL: server.URL + "/v1"}
+
+	endpoints, err := apiclient.getGithubMetaDomains()
+	if err != nil {
+		t.Fatalf("getGithubMetaDomains returned error: %v", err)
+	}
+
+	want := map[string]bool{
+		"github.com":          false,
+		"api.github.com":      false,
+		"codeload.github.com": false,
+	}
+	for _, e := range endpoints {
+		if e.port != 443 {
+			t.Fatalf("endpoint %s port = %d, want 443", e.domainName, e.port)
+		}
+		if _, ok := want[e.domainName]; !ok {
+			t.Fatalf("unexpected endpoint %q; githubusercontent.com domains must be filtered out", e.domainName)
+		}
+		want[e.domainName] = true
+	}
+	for domain, seen := range want {
+		if !seen {
+			t.Fatalf("expected endpoint %q missing", domain)
+		}
+	}
+}
+
+func Test_getGithubMetaDomains_RetriesOnFailure(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		fmt.Fprint(w, `{"domains":{"actions":["github.com"]}}`)
+	}))
+	defer server.Close()
+
+	apiclient := &ApiClient{Client: newTestHTTPClient(), APIURL: server.URL + "/v1"}
+
+	endpoints, err := apiclient.getGithubMetaDomains()
+	if err != nil {
+		t.Fatalf("getGithubMetaDomains returned error: %v", err)
+	}
+	if len(endpoints) != 1 || endpoints[0].domainName != "github.com" {
+		t.Fatalf("endpoints = %+v, want [github.com]", endpoints)
+	}
+	if got := calls.Load(); got != 3 {
+		t.Fatalf("server called %d times, want 3", got)
+	}
+}
+
+func Test_getGithubMetaDomains_ErrorAfterRetries(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	apiclient := &ApiClient{Client: newTestHTTPClient(), APIURL: server.URL + "/v1"}
+
+	endpoints, err := apiclient.getGithubMetaDomains()
+	if err == nil {
+		t.Fatalf("expected error after retries, got endpoints %+v", endpoints)
+	}
+	if got := calls.Load(); got != 3 {
+		t.Fatalf("server called %d times, want 3", got)
+	}
+}


### PR DESCRIPTION
Fetch GitHub Actions endpoints from the GitHub meta API and add them to the implicit endpoint list, with retries on failure. Skip domains under githubusercontent.com because existing wildcard implicit endpoints already cover them. If the fetch fails, the hardcoded implicit endpoints remain as the baseline.